### PR TITLE
Added custom prospect field support as client init options

### DIFF
--- a/lib/pardot/PardotAPI.js
+++ b/lib/pardot/PardotAPI.js
@@ -8,6 +8,7 @@ var PardotAPI_v3 = require('./PardotAPI_v3');
  *  - version   The API version to use (v2). Defaults to v2.
  *  - json   If the API should return XML (default) or JSON.  Set to true to return JSON
  *  - userAgent Custom User-Agent description to use in the request header.
+ *  - prospectCustomFields: A string array of custom fields
  *
  * @param apiKey The API key to access the Pardot API with
  * @param accessToken The oAuth accesstoken if already completed for the user, or null if not

--- a/lib/pardot/PardotAPI_v3.js
+++ b/lib/pardot/PardotAPI_v3.js
@@ -1,7 +1,8 @@
 var http = require('http'),
     request = require('request'),
     querystring = require('querystring'),
-    helpers = require('./helpers');
+    helpers = require('./helpers'),
+    _ = require('underscore');
 
 /**
  * Pardot API wrapper for the API version 1.3
@@ -27,13 +28,17 @@ function PardotAPI_v3 (options, callback) {
   this.responseJSON = (options.json) ? 'response=JSON' : '';
   this.userAgent    = options.userAgent+' ' || '';
   this.DEBUG        = options.DEBUG || false;
-
+  
   var availableParams = ['email', 'password', 'user_key'];
   var givenParams = {
     email: options.email,
     password: options.password,
     user_key: this.userKey
   };
+
+  if (options.prospectCustomFields && options.prospectCustomFields.length) {
+     prospect_fields = _.union(options.prospectCustomFields, prospect_fields);
+  } 
 
   if(!this.apiKey && options.email && options.password) {
     this.execute('login', '', availableParams, givenParams, function(error, data) {
@@ -54,6 +59,7 @@ function PardotAPI_v3 (options, callback) {
   {
     callback(null, this);
   }
+
 }
 
 module.exports = PardotAPI_v3;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-pardot",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A node.js wrapper for the Pardot API.",
   "author": {
     "name": "Jeff Zabel",
@@ -14,6 +14,7 @@
     "url": "https://github.com/Datahero/node-pardot.git"
   },
   "dependencies": {
-    "request": "2.x.x"
+    "request": "2.x.x",
+    "underscore": "1.8.3"
   }
 }


### PR DESCRIPTION
@jzabel I too needed to be able to do custom field updates with our Pardot account.  The existing pull request totally does the job, except the implementation seemed to be something that should be driven off of options, rather than a separate method the user would have to call.  Check out the P.R. and let me know if there's anything else that could be done around this.  Thanks!
